### PR TITLE
Fix CMP0115 warning by adding extensions to all source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,12 @@ link_directories(
     ${CMAKE_SOURCE_DIR}
 )
 
-# list of modules to build final firmware (without extension .c or .cpp)
+# list of modules to build final firmware
 add_executable(${PROJECT_NAME}
-    src/main
-    src/startup/startup
-    src/startup/stack
-    src/startup/handlers_cm
+    src/main.cpp
+    src/startup/startup.cpp
+    src/startup/stack.cpp
+    src/startup/handlers_cm.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}


### PR DESCRIPTION
First of all, thank you for providing this useful template.

Starting from version 3.20, CMake requires all source files to have their extensions explicitly specified (see [CMake policy CMP0115](https://cmake.org/cmake/help/latest/policy/CMP0115.html) for details). Building the project with a recent version of CMake will therefore result in the following warning for every source file without an explicit extension:

```
CMake Warning (dev) at CMakeLists.txt:55 (add_executable):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
```

This pull request makes the code compliant with CMP0115 by adding the appropriate extensions to all source files in CMakeLists.txt.